### PR TITLE
feat(notification-report): implement email notifications via Gmail SM…

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -31,3 +31,7 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### Environment Variables ###
+.env
+*.env

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -63,6 +63,17 @@
 			<version>1.14.0</version>
 		</dependency>
 
+		
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-mail</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-thymeleaf</artifactId>
+		</dependency>
+
 		<dependency>
 			<groupId>org.hibernate.orm</groupId>
 			<artifactId>hibernate-spatial</artifactId>
@@ -90,21 +101,25 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-<dependency>
-    <groupId>org.locationtech.jts</groupId>
-    <artifactId>jts-core</artifactId>
-    <version>1.19.0</version>
-</dependency>
-<dependency>
-    <groupId>com.vladmihalcea</groupId>
-    <artifactId>hibernate-types-60</artifactId>
-    <version>2.21.1</version>
-</dependency>
-<dependency>
-	<groupId>me.paulschwarz</groupId>
-	<artifactId>spring-dotenv</artifactId>
-	<version>4.0.0</version>
-</dependency>
+
+		<dependency>
+			<groupId>org.locationtech.jts</groupId>
+			<artifactId>jts-core</artifactId>
+			<version>1.19.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.vladmihalcea</groupId>
+			<artifactId>hibernate-types-60</artifactId>
+			<version>2.21.1</version>
+		</dependency>
+
+		<dependency>
+			<groupId>me.paulschwarz</groupId>
+			<artifactId>spring-dotenv</artifactId>
+			<version>4.0.0</version>
+		</dependency>
+		
 	</dependencies>
 	
 

--- a/backend/src/main/java/com/ues/parcial/config/EmailConfig.java
+++ b/backend/src/main/java/com/ues/parcial/config/EmailConfig.java
@@ -1,0 +1,54 @@
+package com.ues.parcial.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+import org.springframework.beans.factory.annotation.Value;
+
+@Configuration
+public class EmailConfig {
+
+    @Value("${EMAIL_USERNAME}")
+    private String username;
+
+    @Value("${EMAIL_PASSWORD}")
+    private String password;
+
+    @Value("${EMAIL_HOST:smtp.gmail.com}")
+    private String host;
+
+    @Value("${EMAIL_PORT:587}")
+    private String port;
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth", "true");
+        properties.put("mail.smtp.starttls.enable", "true");
+        properties.put("mail.smtp.host", this.host);
+        properties.put("mail.smtp.port", this.port); 
+        properties.put("mail.smtp.ssl.trust", this.host); 
+        return properties;
+    }
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(this.host);
+        mailSender.setPort(Integer.parseInt(this.port));
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setJavaMailProperties(getMailProperties());
+        return mailSender;
+    }
+
+    @Bean
+    public ResourceLoader resourceLoader(){
+        return new DefaultResourceLoader();
+    } 
+}

--- a/backend/src/main/java/com/ues/parcial/controllers/NotificationController.java
+++ b/backend/src/main/java/com/ues/parcial/controllers/NotificationController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ues.parcial.Models.Enums.NotificationChannel;
+import com.ues.parcial.dtos.notification.CreateMultiNotificationsDto;
 import com.ues.parcial.dtos.notification.CreateNotificationDto;
 import com.ues.parcial.dtos.notification.UpdateNotificationStatusDto;
 import com.ues.parcial.services.NotificationService;
@@ -35,6 +36,11 @@ public class NotificationController {
     @PostMapping
     public ResponseEntity<?> createNotification(@Valid @RequestBody CreateNotificationDto dto) {
         return ResponseEntity.ok(notificationService.toResponseDto(notificationService.createNotification(dto)));
+    }
+
+    @PostMapping("/bulk")
+    public ResponseEntity<?> sendBulkNotifications(@Valid @RequestBody CreateMultiNotificationsDto dto) {
+        return ResponseEntity.ok(notificationService.createAndSendNotifications(dto));
     }
 
     @PatchMapping("/{id}/status")

--- a/backend/src/main/java/com/ues/parcial/controllers/ReportController.java
+++ b/backend/src/main/java/com/ues/parcial/controllers/ReportController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.ues.parcial.dtos.report.ReportRequestDto;
 import com.ues.parcial.dtos.report.ReportResponseDto;
 import com.ues.parcial.dtos.report.ReportUpdateDto;
+import com.ues.parcial.dtos.report.ReportUpdateStateDto;
 import com.ues.parcial.services.ReportService;
 
 import jakarta.validation.Valid;
@@ -42,6 +43,11 @@ public class ReportController {
         return ResponseEntity.ok(reportService.toResponseDto(reportService.updateReport(id, dto)));
     }
 
+    @PatchMapping("/{id}/state")
+    public ResponseEntity<?> updateReportState(@PathVariable UUID id, @Valid @RequestBody ReportUpdateStateDto dto) {
+        return ResponseEntity.ok(reportService.toResponseDto(reportService.updateReportState(id, dto)));
+    }
+
     @PatchMapping("/{id}/deactivate")
     public ResponseEntity<?> deactivate(@PathVariable UUID id) {
         reportService.softDeleteReport(id);
@@ -56,5 +62,10 @@ public class ReportController {
     @GetMapping
     public ResponseEntity<?> getActiveReports() {
         return ResponseEntity.ok(reportService.toResponseDtoList(reportService.getAllActiveReports()));
+    }
+
+    @GetMapping("/reporter/{reporterId}")
+    public ResponseEntity<?> getReportsByReporter(@PathVariable String reporterId) {
+        return ResponseEntity.ok(reportService.toResponseDtoList(reportService.getReportsByReporter(reporterId)));
     }
 }

--- a/backend/src/main/java/com/ues/parcial/dtos/notification/BulkNotificationResult.java
+++ b/backend/src/main/java/com/ues/parcial/dtos/notification/BulkNotificationResult.java
@@ -1,0 +1,8 @@
+package com.ues.parcial.dtos.notification;
+
+import java.util.List;
+
+public record BulkNotificationResult(
+    List<NotificationResponseDto> successful,
+    List<NotificationFailed> failed
+) {}

--- a/backend/src/main/java/com/ues/parcial/dtos/notification/CreateMultiNotificationsDto.java
+++ b/backend/src/main/java/com/ues/parcial/dtos/notification/CreateMultiNotificationsDto.java
@@ -1,0 +1,28 @@
+package com.ues.parcial.dtos.notification;
+
+import java.util.List;
+import java.util.Map;
+
+import com.ues.parcial.Models.Enums.NotificationChannel;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CreateMultiNotificationsDto {
+
+    @NotNull(message = "User IDs cannot be null")
+    private List<String> userIds; 
+
+    @NotNull(message = "Notification channel cannot be null")
+    private NotificationChannel channel; 
+
+    @NotNull(message = "Payload cannot be null")
+    private Map<String, Object> payload;
+}

--- a/backend/src/main/java/com/ues/parcial/dtos/notification/CreateNotificationDto.java
+++ b/backend/src/main/java/com/ues/parcial/dtos/notification/CreateNotificationDto.java
@@ -25,4 +25,6 @@ public class CreateNotificationDto {
 
     @NotNull(message = "payload is required")
     private Map<String, Object> payload;
+
+    private boolean sendNotification = false; // This flag indicates whether the notification should be sent or not.
 }

--- a/backend/src/main/java/com/ues/parcial/dtos/notification/NotificationFailed.java
+++ b/backend/src/main/java/com/ues/parcial/dtos/notification/NotificationFailed.java
@@ -1,0 +1,6 @@
+package com.ues.parcial.dtos.notification;
+
+public record NotificationFailed(
+    String userId,
+    String error
+) {}

--- a/backend/src/main/java/com/ues/parcial/dtos/report/ReportUpdateStateDto.java
+++ b/backend/src/main/java/com/ues/parcial/dtos/report/ReportUpdateStateDto.java
@@ -1,0 +1,17 @@
+package com.ues.parcial.dtos.report;
+
+import com.ues.parcial.Models.Enums.ReportState;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ReportUpdateStateDto {
+    @NotNull(message = "New state cannot be null")
+    ReportState newState;
+
+    // Optional reason for state change
+    String changeReason;
+}

--- a/backend/src/main/java/com/ues/parcial/exceptions/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/ues/parcial/exceptions/GlobalExceptionHandler.java
@@ -36,9 +36,15 @@ public class GlobalExceptionHandler  {
         return buildResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
     }
 
+    // When a phone number format is invalid
     @ExceptionHandler(InvalidPhoneFormatException.class)
     public ResponseEntity<Map<String, Object>> handleInvalidPhone(InvalidPhoneFormatException ex) {
         return buildResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    @ExceptionHandler(NotificationSendException.class)
+    public ResponseEntity<Map<String, Object>> handleNotificationException(NotificationSendException ex) {
+        return buildResponse(HttpStatus.BAD_GATEWAY, ex.getMessage());
     }
 
     // When validation on an argument annotated with @Valid fails (for example @NotNull, @Size, etc.)

--- a/backend/src/main/java/com/ues/parcial/exceptions/NotificationSendException.java
+++ b/backend/src/main/java/com/ues/parcial/exceptions/NotificationSendException.java
@@ -1,0 +1,12 @@
+package com.ues.parcial.exceptions;
+
+public class NotificationSendException extends RuntimeException {
+    
+    public NotificationSendException(String message) {
+        super(message);
+    }
+
+    public NotificationSendException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/ues/parcial/services/EmailService.java
+++ b/backend/src/main/java/com/ues/parcial/services/EmailService.java
@@ -1,0 +1,206 @@
+package com.ues.parcial.services;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.ues.parcial.Models.Notification;
+import com.ues.parcial.Models.Report;
+import com.ues.parcial.Models.Enums.NotificationChannel;
+import com.ues.parcial.Models.Enums.ReportState;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+    private final TemplateEngine templateEngine;
+    private static final Logger logger = LoggerFactory.getLogger(EmailService.class);
+
+    /**
+     * Sends an email based on the notification payload.
+     * Variables are extracted from the Notification payload (JSON).
+     */
+    public void sendNotificationEmail(Notification notification) throws MessagingException {
+        if (notification == null || notification.getUser() == null || notification.getNotificationChannel() != NotificationChannel.EMAIL) {
+            return; // skip if notification is invalid or not email
+        }
+
+        JsonNode payload = notification.getPayload();
+        Map<String, Object> variables = new HashMap<>();
+
+        // Extract variables from payload
+        if (payload != null && payload.isObject()) {
+            Map<String, String> expectedKeys = Map.of(
+                "subject", "title",
+                "message", "message",
+                "name", "name",
+                "lastname", "lastname",
+                "link", "link"
+            );
+
+            // Map payload keys to template variable keys
+            expectedKeys.forEach((jsonKey, variableKey) -> {
+                JsonNode value = payload.get(jsonKey);
+                if (value != null && !value.isNull()) {
+                    variables.put(variableKey, value.asText());
+                }
+            });
+        }
+
+        // Add user data (in case payload didn't include it)
+        if (!variables.containsKey("name")) {
+            variables.put("name", notification.getUser().getName());
+        }
+        if (!variables.containsKey("lastname")) {
+            variables.put("lastname", notification.getUser().getLastName());
+        }
+
+        // Prepare Thymeleaf context
+        Context context = new Context();
+        context.setVariables(variables);
+
+        // Process template
+        String htmlContent = templateEngine.process("notification-template", context);
+
+        // Build the email
+        MimeMessage message = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+        helper.setTo(notification.getUser().getEmail());
+        helper.setSubject((String) variables.getOrDefault("title", "Notification System"));
+        helper.setText(htmlContent, true);
+
+        mailSender.send(message);
+    }
+
+    // Send report status email with specific template based on state
+    public void sendReportStatusEmail(Report report, ReportState oldState, ReportState newState, String changeReason) 
+            throws MessagingException {
+        
+        if (report == null || report.getReporter() == null) {
+            logger.warn("Cannot send email: report or reporter is null");
+            return;
+        }
+        
+        try {
+            // Prepare template variables
+            Map<String, Object> variables = prepareReportTemplateVariables(report, oldState, newState, changeReason);
+            
+            // This will select the appropriate template based on the new state
+            String templateName = getCompleteTemplateForState(newState);
+            String emailSubject = getEmailSubjectForState(newState, report.getTitle());
+            
+            logger.info("Using template: {}", templateName);
+            
+            Context context = new Context();
+            context.setVariables(variables);
+            String fullEmailContent = templateEngine.process(templateName, context);
+            
+            sendReportEmail(report.getReporter().getEmail(), emailSubject, fullEmailContent); // Send email
+            
+            logger.info("Email sent successfully for report {} status change: {} -> {}", 
+                    report.getId(), oldState, newState);
+            
+        } catch (Exception e) {
+            logger.error("Failed to send report status email for report {}: {}", 
+                        report.getId(), e.getMessage(), e);
+            throw e;
+        }
+    }
+    
+    // Prepare variables for the report status email template
+    private Map<String, Object> prepareReportTemplateVariables(Report report, ReportState oldState, ReportState newState, String changeReason) {
+        Map<String, Object> variables = new HashMap<>();
+
+        String oldStateStr = (oldState != null) ? oldState.toString() : "New Report";
+        
+        variables.put("userName", report.getReporter().getName());
+        variables.put("reportTitle", report.getTitle());
+        variables.put("reportId", report.getId().toString());
+        variables.put("oldStatus", oldStateStr);
+        variables.put("newStatus", newState.toString());
+        variables.put("changeDate", formatDate(java.time.OffsetDateTime.now()));
+        variables.put("changeReason", changeReason);
+        variables.put("viewReportLink", buildReportViewLink(report.getId()));
+        variables.put("emailTitle", getEmailTitleForState(newState));
+        
+        return variables;
+    }
+    
+    // Determine the complete template name based on report state
+    private String getCompleteTemplateForState(ReportState state) {
+        return "emails/reports/status-changed/" + state.name().toLowerCase();
+    }
+    
+    // Title for the email based on report state
+    private String getEmailTitleForState(ReportState state) {
+        switch (state) {
+            case VALIDATED: return "Report Validated- UrbanoFix";
+            case REJECTED: return "Report Rejected - UrbanoFix";
+            case ASSIGNED: return "Report Assigned - UrbanoFix";
+            case IN_PROGRESS: return "Report in Progress - UrbanoFix";
+            case RESOLVED: return "Report Resolved! - UrbanoFix";
+            case NO_PROCEDE: return "Report No Procede - UrbanoFix";
+            default: return "Report update - UrbanoFix";
+        }
+    }
+    
+    // Subject line for the email based on report state
+    private String getEmailSubjectForState(ReportState state, String reportTitle) {
+        switch (state) {
+            case VALIDATED: return "✅ Your report has been validated: " + reportTitle;
+            case REJECTED: return "❌ Report rejected: " + reportTitle;
+            case ASSIGNED: return "👥 Report assigned to team: " + reportTitle;
+            case IN_PROGRESS: return "🛠️ Report in progress: " + reportTitle;
+            case RESOLVED: return "🎉 Report resolved!: " + reportTitle;
+            case NO_PROCEDE: return "Reporte no procede: " + reportTitle;
+            default: return "Report update: " + reportTitle;
+        }
+    }
+    
+    // Format date to a readable string
+    private String formatDate(java.time.OffsetDateTime date) {
+        java.time.format.DateTimeFormatter formatter = java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy 'a las' HH:mm");
+        return date.format(formatter);
+    }
+    
+    // Build link to view the report
+    private String buildReportViewLink(java.util.UUID reportId) {
+        return "https://urbanofix.com/reports/" + reportId.toString();
+    }
+    
+    // Send the email with given content
+    private void sendReportEmail(String to, String subject, String htmlContent) throws MessagingException {
+        MimeMessage message = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+        
+        helper.setTo(to);
+        helper.setSubject(subject);
+        helper.setText(htmlContent, true);
+        
+        mailSender.send(message);
+    }
+
+    // Plain text option in case we ever need to use only plain text without a template
+    public void sendPlainEmail(String to, String subject, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject(subject);
+        message.setText(text);
+        mailSender.send(message);
+    }
+}

--- a/backend/src/main/java/com/ues/parcial/services/events/ReportStatusChangedEvent.java
+++ b/backend/src/main/java/com/ues/parcial/services/events/ReportStatusChangedEvent.java
@@ -1,0 +1,24 @@
+package com.ues.parcial.services.events;
+
+import org.springframework.context.ApplicationEvent;
+
+import com.ues.parcial.Models.Report;
+import com.ues.parcial.Models.Enums.ReportState;
+
+import lombok.Getter;
+
+@Getter
+public class ReportStatusChangedEvent extends ApplicationEvent {
+    private final Report report;
+    private final ReportState oldState;
+    private final ReportState newState;
+    private final String changeReason; // Optionally, reason for the change
+
+    public ReportStatusChangedEvent(Object source, Report report, ReportState oldState, ReportState newState, String changeReason) {
+        super(source);
+        this.report = report;
+        this.oldState = oldState;
+        this.newState = newState;
+        this.changeReason = changeReason;
+    }
+}

--- a/backend/src/main/java/com/ues/parcial/services/events/ReportStatusChangedListener.java
+++ b/backend/src/main/java/com/ues/parcial/services/events/ReportStatusChangedListener.java
@@ -1,0 +1,159 @@
+package com.ues.parcial.services.events;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import com.ues.parcial.Models.Report;
+import com.ues.parcial.Models.Enums.NotificationChannel;
+import com.ues.parcial.Models.Enums.ReportState;
+import com.ues.parcial.dtos.notification.CreateNotificationDto;
+import com.ues.parcial.services.EmailService;
+import com.ues.parcial.services.NotificationService;
+
+@Component
+public class ReportStatusChangedListener {
+    
+    private static final Logger logger = LoggerFactory.getLogger(ReportStatusChangedListener.class);
+    private final EmailService emailService;
+    private final NotificationService notificationService;
+    
+    public ReportStatusChangedListener(EmailService emailService, NotificationService notificationService) {
+        this.emailService = emailService;
+        this.notificationService = notificationService;
+    }
+    
+    @EventListener
+    @Async
+    public void handleReportStatusChanged(ReportStatusChangedEvent event) {
+        Report report = event.getReport();
+        ReportState newState = event.getNewState();
+        ReportState oldState = event.getOldState();
+        
+        logger.info("Processing status change for report {}: {} -> {}", 
+                    report.getId(), oldState, newState);
+        
+        // Only notify if the report is active and there is a real state change
+        if (shouldNotifyUser(report, oldState, newState)) {
+            sendStatusChangeEmail(report, oldState, newState, event.getChangeReason());
+            saveNotificationRecord(report, oldState, newState, event.getChangeReason()); // Save notification in db
+        }
+    }
+    
+    private boolean shouldNotifyUser(Report report, ReportState oldState, ReportState newState) {
+        // Notify only if: 1. Report is active, 2. State has actually change and 3. There is a reporter associated with the report
+        return report.isActive() 
+            && !newState.equals(oldState)
+            && report.getReporter() != null;
+    }
+    
+    private void sendStatusChangeEmail(Report report, ReportState oldState, ReportState newState, String changeReason) {
+        try {
+            emailService.sendReportStatusEmail(report, oldState, newState, changeReason);
+            
+            logger.info("Status change email sent for report {} to user {}", 
+                        report.getId(), report.getReporter().getId());
+            
+        } catch (Exception e) {
+            logger.error("Error sending status change email for report {}: {}", 
+                        report.getId(), e.getMessage(), e);
+        }
+    }
+    
+    // Save notification record without sending email
+    private void saveNotificationRecord(Report report, ReportState oldState, ReportState newState, String changeReason) {
+        try {
+            CreateNotificationDto notificationDto = new CreateNotificationDto();
+            notificationDto.setUserId(report.getReporter().getId());
+            notificationDto.setChannel(NotificationChannel.EMAIL);
+            notificationDto.setSendNotification(false); // No email sending, just save record because email already sent
+            
+            Map<String, Object> payload = buildNotificationPayload(report, oldState, newState, changeReason);
+            notificationDto.setPayload(payload);
+            
+            notificationService.createNotification(notificationDto);
+            
+            logger.debug("Notification record saved for report {} status change", report.getId());
+            
+        } catch (Exception e) {
+            logger.warn("Failed to save notification record for report {}: {}", 
+                        report.getId(), e.getMessage());
+        }
+    }
+    
+    // Build payload for notification record.
+    private Map<String, Object> buildNotificationPayload(Report report, ReportState oldState, ReportState newState, String changeReason) {
+        Map<String, Object> payload = new HashMap<>();
+
+        String oldStateStr = (oldState != null) ? oldState.toString() : "New Report";
+        
+        payload.put("subject", "Update on Your Report Status");
+        payload.put("title", "Report Status Updated");
+        payload.put("message", buildStatusMessage(report, oldState, newState, changeReason));
+        payload.put("reportId", report.getId().toString());
+        payload.put("reportTitle", report.getTitle());
+        payload.put("oldStatus", oldStateStr);
+        payload.put("newStatus", newState.toString());
+        payload.put("userName", report.getReporter().getName());
+        payload.put("changeDate", java.time.OffsetDateTime.now().toString());
+        
+        if (changeReason != null && !changeReason.trim().isEmpty()) {
+            payload.put("changeReason", changeReason);
+        }
+        
+        payload.put("viewReportLink", buildReportViewLink(report.getId()));
+        
+        return payload;
+    }
+    
+    // Build the status change message for notification payload
+    private String buildStatusMessage(Report report, ReportState oldState, ReportState newState, String changeReason) {
+
+        String oldStateStr = (oldState != null) ? oldState.toString() : "New Report";
+        
+        String baseMessage = String.format(
+            "Hello %s,\n\nThe status of your report \\\"%s\\\" has changed from %s to %s.",
+            report.getReporter().getName(),
+            report.getTitle(),
+            oldStateStr,
+            newState.toString()
+        );
+        
+        String statusMessage = getStatusSpecificMessage(newState);
+        String reasonMessage = changeReason != null ? 
+            String.format("\n\nReason for the change: %s", changeReason) : "";
+        
+        return baseMessage + statusMessage + reasonMessage + 
+                "\n\nYou can view the details of your report at the following link:" + 
+                buildReportViewLink(report.getId());
+    }
+    
+    private String getStatusSpecificMessage(ReportState newState) {
+        switch (newState) {
+            case VALIDATED:
+                return "\n\nYour report has been validated and is now being processed by the appropriate authorities.";
+            case REJECTED:
+                return "\n\nUnfortunately, your report does not meet the necessary criteria to be processed.";
+            case ASSIGNED:
+                return "\n\nYour report has been assigned to a specialized team for handling.";
+            case IN_PROGRESS:
+                return "\n\nYour report is currently being actively handled by the corresponding team.";
+            case RESOLVED:
+                return "\n\nGreat news! The reported issue has been successfully resolved.";
+            case NO_PROCEDE:
+                return "\n\nYour report cannot proceed according to the established guidelines.";
+            default:
+                return "\n\nThe report has progressed in its handling process.";
+        }
+    }
+    
+    // Build link to view the report
+    private String buildReportViewLink(java.util.UUID reportId) {
+        return String.format("https://urbanofix.com/reports/%s", reportId.toString());
+    }
+}

--- a/backend/src/main/java/com/ues/parcial/services/notification/senders/EmailNotificationSender.java
+++ b/backend/src/main/java/com/ues/parcial/services/notification/senders/EmailNotificationSender.java
@@ -1,0 +1,26 @@
+package com.ues.parcial.services.notification.senders;
+
+import org.springframework.stereotype.Service;
+
+import com.ues.parcial.Models.Notification;
+import com.ues.parcial.Models.Enums.NotificationChannel;
+import com.ues.parcial.services.EmailService;
+
+import jakarta.mail.MessagingException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class EmailNotificationSender implements NotificationSender {
+    private final EmailService emailService;
+
+    @Override
+    public void send(Notification notification) throws MessagingException {
+        emailService.sendNotificationEmail(notification);
+    }
+
+    @Override
+    public NotificationChannel getChannelType() {
+        return NotificationChannel.EMAIL;
+    }
+}

--- a/backend/src/main/java/com/ues/parcial/services/notification/senders/NotificationSender.java
+++ b/backend/src/main/java/com/ues/parcial/services/notification/senders/NotificationSender.java
@@ -1,0 +1,9 @@
+package com.ues.parcial.services.notification.senders;
+
+import com.ues.parcial.Models.Notification;
+import com.ues.parcial.Models.Enums.NotificationChannel;
+
+public interface NotificationSender {
+    void send(Notification notification) throws Exception;
+    NotificationChannel getChannelType();
+}

--- a/backend/src/main/resources/templates/emails/reports/status-changed/assigned.html
+++ b/backend/src/main/resources/templates/emails/reports/status-changed/assigned.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title th:text="${emailTitle}">Report assigned - UrbanoFix</title>
+    <style>
+        body { 
+            font-family: 'Arial', sans-serif; 
+            line-height: 1.6; 
+            color: #333; 
+            margin: 0; 
+            padding: 0; 
+            background-color: #f4f4f4;
+        }
+        .container { 
+            max-width: 600px; 
+            margin: 0 auto; 
+            background: #ffffff; 
+            border-radius: 8px; 
+            overflow: hidden;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        .header { 
+            background: #2c5aa0; 
+            color: white; 
+            padding: 20px; 
+            text-align: center;
+        }
+        .header h1 { 
+            margin: 0; 
+            font-size: 24px;
+        }
+        .content { 
+            padding: 30px; 
+        }
+        .status-badge {
+            display: inline-block;
+            padding: 8px 16px;
+            border-radius: 20px;
+            color: white;
+            font-weight: bold;
+            margin: 10px 0;
+        }
+        .report-details {
+            background: #f8f9fa;
+            border-left: 4px solid #2c5aa0;
+            padding: 15px;
+            margin: 20px 0;
+            border-radius: 4px;
+        }
+        .button {
+            display: inline-block;
+            background: #2c5aa0;
+            color: white;
+            padding: 12px 24px;
+            text-decoration: none;
+            border-radius: 5px;
+            margin: 15px 0;
+        }
+        .footer { 
+            text-align: center; 
+            margin-top: 30px; 
+            font-size: 0.9em; 
+            color: #666;
+            padding: 20px;
+            background: #f8f9fa;
+        }
+        .reason-box {
+            background: #fff3cd;
+            border: 1px solid #ffeaa7;
+            border-radius: 4px;
+            padding: 15px;
+            margin: 15px 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1 th:text="${emailTitle}">UrbanoFix</h1>
+        </div>
+        
+        <div class="content">
+            <h2> Report Assigned</h2>
+            
+            <p>Hi <strong th:text="${userName}">User</strong>,</p>
+            
+            <p>Your report has been <strong>assigned</strong> to a specialized team for attention..</p>
+            
+            <div class="report-details">
+                <p><strong>Report ID:</strong> <span th:text="${reportId}">N/A</span></p>
+                <p><strong>Title:</strong> <span th:text="${reportTitle}">Report title</span></p>
+                <p><strong>Assignment Date:</strong> <span th:text="${changeDate}">Date</span></p>
+            </div>
+
+            <div class="status-badge" style="background: #6f42c1;">
+                CURRENT STATUS: ASSIGNED
+            </div>
+
+            <p>
+                <a th:href="${viewReportLink}" class="button">Track Progress</a>
+            </p>
+
+            <p>The assigned team will start working on the solution soon.</p>
+        </div>
+        
+        <div class="footer">
+            <p>© 2025 - UrbanoFix Notification System.</p>
+            <p>This is an automated message, please do not reply.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/backend/src/main/resources/templates/emails/reports/status-changed/in_progress.html
+++ b/backend/src/main/resources/templates/emails/reports/status-changed/in_progress.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title th:text="${emailTitle}">Report in progress - UrbanoFix</title>
+    <style>
+        body { 
+            font-family: 'Arial', sans-serif; 
+            line-height: 1.6; 
+            color: #333; 
+            margin: 0; 
+            padding: 0; 
+            background-color: #f4f4f4;
+        }
+        .container { 
+            max-width: 600px; 
+            margin: 0 auto; 
+            background: #ffffff; 
+            border-radius: 8px; 
+            overflow: hidden;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        .header { 
+            background: #2c5aa0; 
+            color: white; 
+            padding: 20px; 
+            text-align: center;
+        }
+        .header h1 { 
+            margin: 0; 
+            font-size: 24px;
+        }
+        .content { 
+            padding: 30px; 
+        }
+        .status-badge {
+            display: inline-block;
+            padding: 8px 16px;
+            border-radius: 20px;
+            color: white;
+            font-weight: bold;
+            margin: 10px 0;
+        }
+        .report-details {
+            background: #f8f9fa;
+            border-left: 4px solid #2c5aa0;
+            padding: 15px;
+            margin: 20px 0;
+            border-radius: 4px;
+        }
+        .button {
+            display: inline-block;
+            background: #2c5aa0;
+            color: white;
+            padding: 12px 24px;
+            text-decoration: none;
+            border-radius: 5px;
+            margin: 15px 0;
+        }
+        .footer { 
+            text-align: center; 
+            margin-top: 30px; 
+            font-size: 0.9em; 
+            color: #666;
+            padding: 20px;
+            background: #f8f9fa;
+        }
+        .reason-box {
+            background: #fff3cd;
+            border: 1px solid #ffeaa7;
+            border-radius: 4px;
+            padding: 15px;
+            margin: 15px 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1 th:text="${emailTitle}">UrbanoFix</h1>
+        </div>
+        
+        <div class="content">
+            <h2>🛠️ Report in Progress</h2>
+            
+            <p>Hi <strong th:text="${userName}">User</strong>,</p>
+            
+            <p>The assigned team is  <strong>actively working</strong> on resolving your report.</p>
+            
+            <div class="report-details">
+                <p><strong>Report ID:</strong> <span th:text="${reportId}">N/A</span></p>
+                <p><strong>Title:</strong> <span th:text="${reportTitle}">Report title</span></p>
+                <p><strong>Start Date:</strong> <span th:text="${changeDate}">Date</span></p>
+            </div>
+
+            <div th:if="${changeReason}" class="reason-box">
+                <p><strong>Team Update:</strong></p>
+                <p th:text="${changeReason}">Team update</p>
+            </div>
+
+            <div class="status-badge" style="background: #fd7e14;">
+                CURRENT STATUS: IN PROGRESS
+            </div>
+
+            <p>
+                <a th:href="${viewReportLink}" class="button">View Current Progress</a>
+            </p>
+
+            <p>We will keep you informed about the progress.</p>
+        </div>
+        
+        <div class="footer">
+            <p>© 2025 - UrbanoFix Notification System.</p>
+            <p>This is an automated message, please do not reply.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/backend/src/main/resources/templates/emails/reports/status-changed/no_procede.html
+++ b/backend/src/main/resources/templates/emails/reports/status-changed/no_procede.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title th:text="${emailTitle}">Report No Procede - UrbanoFix</title>
+    <style>
+        body { 
+            font-family: 'Arial', sans-serif; 
+            line-height: 1.6; 
+            color: #333; 
+            margin: 0; 
+            padding: 0; 
+            background-color: #f4f4f4;
+        }
+        .container { 
+            max-width: 600px; 
+            margin: 0 auto; 
+            background: #ffffff; 
+            border-radius: 8px; 
+            overflow: hidden;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        .header { 
+            background: #2c5aa0; 
+            color: white; 
+            padding: 20px; 
+            text-align: center;
+        }
+        .header h1 { 
+            margin: 0; 
+            font-size: 24px;
+        }
+        .content { 
+            padding: 30px; 
+        }
+        .status-badge {
+            display: inline-block;
+            padding: 8px 16px;
+            border-radius: 20px;
+            color: white;
+            font-weight: bold;
+            margin: 10px 0;
+        }
+        .report-details {
+            background: #f8f9fa;
+            border-left: 4px solid #2c5aa0;
+            padding: 15px;
+            margin: 20px 0;
+            border-radius: 4px;
+        }
+        .button {
+            display: inline-block;
+            background: #2c5aa0;
+            color: white;
+            padding: 12px 24px;
+            text-decoration: none;
+            border-radius: 5px;
+            margin: 15px 0;
+        }
+        .footer { 
+            text-align: center; 
+            margin-top: 30px; 
+            font-size: 0.9em; 
+            color: #666;
+            padding: 20px;
+            background: #f8f9fa;
+        }
+        .reason-box {
+            background: #fff3cd;
+            border: 1px solid #ffeaa7;
+            border-radius: 4px;
+            padding: 15px;
+            margin: 15px 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1 th:text="${emailTitle}">UrbanoFix</h1>
+        </div>
+        
+        <div class="content">
+            <h2>Report No Procede</h2>
+            
+            <p>Hi <strong th:text="${userName}">User</strong>,</p>
+            
+            <p>After reviewing your report, we have determined that it <strong>does not proceed</strong> according to our guidelines.</p>
+            
+            <div class="report-details">
+                <p><strong>Report ID:</strong> <span th:text="${reportId}">N/A</span></p>
+                <p><strong>Title:</strong> <span th:text="${reportTitle}">Report Title</span></p>
+                <p><strong>Decision Date:</strong> <span th:text="${changeDate}">Date</span></p>
+            </div>
+
+            <div th:if="${changeReason}" class="reason-box">
+                <p><strong>Explanation:</strong></p>
+                <p th:text="${changeReason}">Specific reason why it does not proceed</p>
+            </div>
+
+            <div class="status-badge" style="background: #6c757d;">
+                CURRENT STATUS: NOT APPROVED
+            </div>
+
+            <p>If you have any questions about this decision, please contact the support team.</p>
+        </div>
+        
+        <div class="footer">
+            <p>© 2025 - UrbanoFix Notification System.</p>
+            <p>This is an automated message, please do not reply.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/backend/src/main/resources/templates/emails/reports/status-changed/rejected.html
+++ b/backend/src/main/resources/templates/emails/reports/status-changed/rejected.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title th:text="${emailTitle}">Report Rejected - UrbanoFix</title>
+    <style>
+        body { 
+            font-family: 'Arial', sans-serif; 
+            line-height: 1.6; 
+            color: #333; 
+            margin: 0; 
+            padding: 0; 
+            background-color: #f4f4f4;
+        }
+        .container { 
+            max-width: 600px; 
+            margin: 0 auto; 
+            background: #ffffff; 
+            border-radius: 8px; 
+            overflow: hidden;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        .header { 
+            background: #2c5aa0; 
+            color: white; 
+            padding: 20px; 
+            text-align: center;
+        }
+        .header h1 { 
+            margin: 0; 
+            font-size: 24px;
+        }
+        .content { 
+            padding: 30px; 
+        }
+        .status-badge {
+            display: inline-block;
+            padding: 8px 16px;
+            border-radius: 20px;
+            color: white;
+            font-weight: bold;
+            margin: 10px 0;
+        }
+        .report-details {
+            background: #f8f9fa;
+            border-left: 4px solid #2c5aa0;
+            padding: 15px;
+            margin: 20px 0;
+            border-radius: 4px;
+        }
+        .button {
+            display: inline-block;
+            background: #2c5aa0;
+            color: white;
+            padding: 12px 24px;
+            text-decoration: none;
+            border-radius: 5px;
+            margin: 15px 0;
+        }
+        .footer { 
+            text-align: center; 
+            margin-top: 30px; 
+            font-size: 0.9em; 
+            color: #666;
+            padding: 20px;
+            background: #f8f9fa;
+        }
+        .reason-box {
+            background: #fff3cd;
+            border: 1px solid #ffeaa7;
+            border-radius: 4px;
+            padding: 15px;
+            margin: 15px 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1 th:text="${emailTitle}">UrbanoFix</h1>
+        </div>
+        
+        <div class="content">
+            <h2>❌ Report Rejected</h2>
+            
+            <p>Hi <strong th:text="${userName}">User</strong>,</p>
+            
+            <p>We regret to inform you that your report has been <strong>rejected</strong>.</p>
+            
+            <div class="report-details">
+                <p><strong>Report ID:</strong> <span th:text="${reportId}">N/A</span></p>
+                <p><strong>Title:</strong> <span th:text="${reportTitle}">Report Title</span></p>
+                <p><strong>Rejection Date:</strong> <span th:text="${changeDate}">Date</span></p>
+            </div>
+
+            <div th:if="${changeReason}" class="reason-box">
+                <p><strong>Reason for Rejection:</strong></p>
+                <p th:text="${changeReason}">Specific reason</p>
+            </div>
+
+            <div class="status-badge" style="background: #dc3545;">
+                CURRENT STATUS: REJECTED
+            </div>
+
+            <p>If you believe this is a mistake, you can contact the support team.</p>
+        </div>
+        
+        <div class="footer">
+            <p>© 2025 - UrbanoFix Notification System.</p>
+            <p>This is an automated message, please do not reply.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/backend/src/main/resources/templates/emails/reports/status-changed/reported.html
+++ b/backend/src/main/resources/templates/emails/reports/status-changed/reported.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title th:text="${emailTitle}">Report Received - UrbanoFix</title>
+    <style>
+        body { 
+            font-family: 'Arial', sans-serif; 
+            line-height: 1.6; 
+            color: #333; 
+            margin: 0; 
+            padding: 0; 
+            background-color: #f4f4f4;
+        }
+        .container { 
+            max-width: 600px; 
+            margin: 0 auto; 
+            background: #ffffff; 
+            border-radius: 8px; 
+            overflow: hidden;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        .header { 
+            background: #2c5aa0; 
+            color: white; 
+            padding: 20px; 
+            text-align: center;
+        }
+        .header h1 { 
+            margin: 0; 
+            font-size: 24px;
+        }
+        .content { 
+            padding: 30px; 
+        }
+        .status-badge {
+            display: inline-block;
+            padding: 8px 16px;
+            border-radius: 20px;
+            color: white;
+            font-weight: bold;
+            margin: 10px 0;
+        }
+        .report-details {
+            background: #f8f9fa;
+            border-left: 4px solid #2c5aa0;
+            padding: 15px;
+            margin: 20px 0;
+            border-radius: 4px;
+        }
+        .button {
+            display: inline-block;
+            background: #2c5aa0;
+            color: white;
+            padding: 12px 24px;
+            text-decoration: none;
+            border-radius: 5px;
+            margin: 15px 0;
+        }
+        .footer { 
+            text-align: center; 
+            margin-top: 30px; 
+            font-size: 0.9em; 
+            color: #666;
+            padding: 20px;
+            background: #f8f9fa;
+        }
+        .reason-box {
+            background: #fff3cd;
+            border: 1px solid #ffeaa7;
+            border-radius: 4px;
+            padding: 15px;
+            margin: 15px 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1 th:text="${emailTitle}">UrbanoFix</h1>
+        </div>
+        
+        <div class="content">
+            <h2>Report Received!</h2>
+            
+            <p>Hi <strong th:text="${userName}">User</strong>,</p>
+            
+            <p>We have successfully received your report. Our team will review it soon.</p>
+            
+            <div class="report-details">
+                <p><strong>Report ID:</strong> <span th:text="${reportId}">N/A</span></p>
+                <p><strong>Title:</strong> <span th:text="${reportTitle}">Report Title</span></p>
+                <p><strong>Creation Date:</strong> <span th:text="${changeDate}">Date</span></p>
+            </div>
+
+            <div class="status-badge" style="background: #17a2b8;">
+                CURRENT STATUS: REPORTED
+            </div>
+
+            <p>You can track the progress of your report at the following link:</p>
+            <p>
+                <a th:href="${viewReportLink}" class="button">View My Report</a>
+            </p>
+
+            <p>Thank you for helping us improve our community.</p>
+        </div>
+        
+        <div class="footer">
+            <p>© 2025 - UrbanoFix Notification System.</p>
+            <p>This is an automated message, please do not reply.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/backend/src/main/resources/templates/emails/reports/status-changed/resolved.html
+++ b/backend/src/main/resources/templates/emails/reports/status-changed/resolved.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title th:text="${emailTitle}">Report Resolved! - UrbanoFix</title>
+    <style>
+        body { 
+            font-family: 'Arial', sans-serif; 
+            line-height: 1.6; 
+            color: #333; 
+            margin: 0; 
+            padding: 0; 
+            background-color: #f4f4f4;
+        }
+        .container { 
+            max-width: 600px; 
+            margin: 0 auto; 
+            background: #ffffff; 
+            border-radius: 8px; 
+            overflow: hidden;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        .header { 
+            background: #2c5aa0; 
+            color: white; 
+            padding: 20px; 
+            text-align: center;
+        }
+        .header h1 { 
+            margin: 0; 
+            font-size: 24px;
+        }
+        .content { 
+            padding: 30px; 
+        }
+        .status-badge {
+            display: inline-block;
+            padding: 8px 16px;
+            border-radius: 20px;
+            color: white;
+            font-weight: bold;
+            margin: 10px 0;
+        }
+        .report-details {
+            background: #f8f9fa;
+            border-left: 4px solid #2c5aa0;
+            padding: 15px;
+            margin: 20px 0;
+            border-radius: 4px;
+        }
+        .button {
+            display: inline-block;
+            background: #2c5aa0;
+            color: white;
+            padding: 12px 24px;
+            text-decoration: none;
+            border-radius: 5px;
+            margin: 15px 0;
+        }
+        .footer { 
+            text-align: center; 
+            margin-top: 30px; 
+            font-size: 0.9em; 
+            color: #666;
+            padding: 20px;
+            background: #f8f9fa;
+        }
+        .reason-box {
+            background: #fff3cd;
+            border: 1px solid #ffeaa7;
+            border-radius: 4px;
+            padding: 15px;
+            margin: 15px 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1 th:text="${emailTitle}">UrbanoFix</h1>
+        </div>
+        
+        <div class="content">
+            <h2>🎉 Issue Resolved!</h2>
+            
+            <p>Hola <strong th:text="${userName}">Usuario</strong>,</p>
+            
+            <p>Great news! The issue you reported has been <strong>successfully resolved.</p>
+            
+            <div class="report-details">
+                <p><strong>Report ID:</strong> <span th:text="${reportId}">N/A</span></p>
+                <p><strong>Title:</strong> <span th:text="${reportTitle}">Report Title</span></p>
+                <p><strong>Resolution Date:</strong> <span th:text="${changeDate}">Date</span></p>
+            </div>
+
+            <div th:if="${changeReason}" class="reason-box">
+                <p><strong>Resolution Details:</strong></p>
+                <p th:text="${changeReason}">Resolution Details</p>
+            </div>
+
+            <div class="status-badge" style="background: #20c997;">
+                CURRENT STATUS: RESOLVED
+            </div>
+
+            <p>
+                <a th:href="${viewReportLink}" class="button">View Completed Report</a>
+            </p>
+
+            <p>Thank you for helping us improve our city!</p>
+        </div>
+        
+        <div class="footer">
+            <p>© 2025 - UrbanoFix Notification System.</p>
+            <p>This is an automated message, please do not reply.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/backend/src/main/resources/templates/emails/reports/status-changed/validated.html
+++ b/backend/src/main/resources/templates/emails/reports/status-changed/validated.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title th:text="${emailTitle}">Report Validated - UrbanoFix</title>
+    <style>
+        body { 
+            font-family: 'Arial', sans-serif; 
+            line-height: 1.6; 
+            color: #333; 
+            margin: 0; 
+            padding: 0; 
+            background-color: #f4f4f4;
+        }
+        .container { 
+            max-width: 600px; 
+            margin: 0 auto; 
+            background: #ffffff; 
+            border-radius: 8px; 
+            overflow: hidden;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        .header { 
+            background: #2c5aa0; 
+            color: white; 
+            padding: 20px; 
+            text-align: center;
+        }
+        .header h1 { 
+            margin: 0; 
+            font-size: 24px;
+        }
+        .content { 
+            padding: 30px; 
+        }
+        .status-badge {
+            display: inline-block;
+            padding: 8px 16px;
+            border-radius: 20px;
+            color: white;
+            font-weight: bold;
+            margin: 10px 0;
+        }
+        .report-details {
+            background: #f8f9fa;
+            border-left: 4px solid #2c5aa0;
+            padding: 15px;
+            margin: 20px 0;
+            border-radius: 4px;
+        }
+        .button {
+            display: inline-block;
+            background: #2c5aa0;
+            color: white;
+            padding: 12px 24px;
+            text-decoration: none;
+            border-radius: 5px;
+            margin: 15px 0;
+        }
+        .footer { 
+            text-align: center; 
+            margin-top: 30px; 
+            font-size: 0.9em; 
+            color: #666;
+            padding: 20px;
+            background: #f8f9fa;
+        }
+        .reason-box {
+            background: #fff3cd;
+            border: 1px solid #ffeaa7;
+            border-radius: 4px;
+            padding: 15px;
+            margin: 15px 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1 th:text="${emailTitle}">UrbanoFix</h1>
+        </div>
+        
+        <div class="content">
+            <h2>✅ Report Validated</h2>
+            
+            <p>Hi <strong th:text="${userName}">User</strong>,</p>
+            
+            <p>Your report has been <strong>validated</strong> and is now being processed.</p>
+            
+            <div class="report-details">
+                <p><strong>Report ID:</strong> <span th:text="${reportId}">N/A</span></p>
+                <p><strong>Title:</strong> <span th:text="${reportTitle}">Report Title</span></p>
+                <p><strong>Validation Date:</strong> <span th:text="${changeDate}">Date</span></p>
+            </div>
+
+            <div th:if="${changeReason}" class="reason-box">
+                <p><strong>Validators Comment:</strong></p>
+                <p th:text="${changeReason}">Reason for change</p>
+            </div>
+
+            <div class="status-badge" style="background: #28a745;">
+                CURRENT STATE: VALIDATED
+            </div>
+
+            <p>
+                <a th:href="${viewReportLink}" class="button">Track Progress</a>
+            </p>
+
+            <p>The issue will be handled by the appropriate authorities.</p>
+        </div>
+        
+        <div class="footer">
+            <p>© 2025 - UrbanoFix Notification System.</p>
+            <p>This is an automated message, please do not reply.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/backend/src/main/resources/templates/notification-template.html
+++ b/backend/src/main/resources/templates/notification-template.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title th:text="${title}">UrbanoFix</title>
+    <style>
+        body {
+            font-family: 'Segoe UI', Arial, sans-serif;
+            background-color: #f4f6f8;
+            color: #333;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            max-width: 600px;
+            background: #fff;
+            margin: 40px auto;
+            border-radius: 10px;
+            box-shadow: 0 3px 6px rgba(0,0,0,0.1);
+            overflow: hidden;
+        }
+        .header {
+            background-color: #1976d2;
+            color: #fff;
+            padding: 20px;
+            text-align: center;
+            font-size: 20px;
+            font-weight: 600;
+        }
+        .content {
+            padding: 25px;
+        }
+        .greeting {
+            font-size: 16px;
+            margin-bottom: 15px;
+        }
+        .message {
+            font-size: 15px;
+            line-height: 1.5;
+            margin-bottom: 20px;
+        }
+        .button {
+            display: inline-block;
+            background-color: #1976d2;
+            color: #fff !important;
+            padding: 12px 20px;
+            border-radius: 6px;
+            text-decoration: none;
+            font-weight: 500;
+        }
+        .button:hover {
+            background-color: #0d47a1;
+        }
+        .footer {
+            background-color: #f0f0f0;
+            color: #666;
+            text-align: center;
+            font-size: 12px;
+            padding: 15px;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <div class="header" th:text="${title}">UrbanoFix</div>
+    <div class="content">
+        <p class="greeting">
+            Hi <b th:text="${name} + ' ' + ${lastname}">User</b>,
+        </p>
+
+        <p class="message" th:text="${message}"></p>
+
+        <div th:if="${link}">
+            <a th:href="${link}" class="button" target="_blank">See more details</a>
+        </div>
+    </div>
+
+    <div class="footer">
+        © 2025 - UrbanoFix Notification System<br/>
+        This is an automated message, please do not reply.
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
This feature implements email notifications for users through Gmail’s SMTP service. Key changes include:

1. Added configuration classes for SMTP email sending.
2. Implemented EmailService to handle message construction and delivery.
3. Updated the Notification entity to support email data.
4. Added a listener to the Report entity to automatically notify users when a report’s status changes.
5. Introduced two new endpoints for Report:
             PATCH api/reports/{id}/state – update only the status.
              GET api/reports/reporter/{reporterId} – retrieve reports by reporter ID.

6. Included new dependencies for JavaMail and Thymeleaf.
7. Created Thymeleaf templates for different report status change notifications.