### PR TITLE
Add success and error toast notifications for category creation and update

### DIFF
--- a/frontend/src/app/components/categories-form-component/categories-form-component.ts
+++ b/frontend/src/app/components/categories-form-component/categories-form-component.ts
@@ -59,6 +59,11 @@ export class CategoriesFormComponent implements OnInit {
       }
       )
     } else {
+      this.categoryService.createCategory(formvalue).subscribe({
+        next: (response) => {
+          this.cleanForm(Form);
+          this.showSuccessToast('Successfully created');
+        },
       })
     }
   }

--- a/frontend/src/app/components/categories-form-component/categories-form-component.ts
+++ b/frontend/src/app/components/categories-form-component/categories-form-component.ts
@@ -30,6 +30,9 @@ export class CategoriesFormComponent implements OnInit {
     code: ""
   }
 
+  showErrorToast(message: string) {
+    this.messageService.add({ severity: 'error', summary: 'Error', detail: message, life: 3000 });
+  }
 
   showSuccessToast(message: string) {
     this.messageService.add({ severity: 'success', summary: 'Success', detail: message, life: 3000 });
@@ -49,6 +52,9 @@ export class CategoriesFormComponent implements OnInit {
           console.log(response);
           this.cleanForm(Form);
           this.showSuccessToast('Successfully updated');
+        },
+        error: (err) => {
+          this.showErrorToast(err.error.message);
         }
       }
       )

--- a/frontend/src/app/components/categories-form-component/categories-form-component.ts
+++ b/frontend/src/app/components/categories-form-component/categories-form-component.ts
@@ -64,6 +64,9 @@ export class CategoriesFormComponent implements OnInit {
           this.cleanForm(Form);
           this.showSuccessToast('Successfully created');
         },
+        error: (err) => {
+          this.showErrorToast(err.error.message);
+        }
       })
     }
   }

--- a/frontend/src/app/components/categories-form-component/categories-form-component.ts
+++ b/frontend/src/app/components/categories-form-component/categories-form-component.ts
@@ -9,16 +9,19 @@ import { CommonModule } from '@angular/common';
 import { CategoryService } from '../../services/category-service';
 import { ActivatedRoute } from '@angular/router';
 import { OnInit } from '@angular/core';
+import { MessageService } from 'primeng/api';
+import { Toast } from 'primeng/toast';
 
 @Component({
   selector: 'app-categories-form-component',
-  imports: [CardModule, InputTextModule, FormsModule, FloatLabel, ButtonModule, CommonModule],
+  imports: [CardModule, InputTextModule, FormsModule, FloatLabel, ButtonModule, CommonModule, Toast],
   templateUrl: './categories-form-component.html',
-  styleUrl: './categories-form-component.css'
+  styleUrl: './categories-form-component.css',
+  providers: [MessageService]
 })
 export class CategoriesFormComponent implements OnInit {
 
-  constructor(private categoryService: CategoryService, private route: ActivatedRoute) {
+  constructor(private categoryService: CategoryService, private route: ActivatedRoute, private messageService: MessageService) {
   }
 
   category: Category = {
@@ -27,7 +30,12 @@ export class CategoriesFormComponent implements OnInit {
     code: ""
   }
 
-  cleanForm(Form: NgForm){
+
+  showSuccessToast(message: string) {
+    this.messageService.add({ severity: 'success', summary: 'Success', detail: message, life: 3000 });
+  }
+
+  cleanForm(Form: NgForm) {
     this.category.id = null;
     this.category.name = "";
     this.category.code = "";
@@ -36,14 +44,15 @@ export class CategoriesFormComponent implements OnInit {
 
   createOrUpdateCategory(formvalue: Category, Form: NgForm) {
     if (this.category.id !== null) {
-      this.categoryService.partiallyUpdateCategory(this.category.id, formvalue).subscribe((response) => {
-        console.log(response)
-        this.cleanForm(Form);
-      })
+      this.categoryService.partiallyUpdateCategory(this.category.id, formvalue).subscribe({
+        next: (response) => {
+          console.log(response);
+          this.cleanForm(Form);
+          this.showSuccessToast('Successfully updated');
+        }
+      }
+      )
     } else {
-      this.categoryService.createCategory(formvalue).subscribe((response) => {
-        console.log(response)
-        this.cleanForm(Form)
       })
     }
   }


### PR DESCRIPTION
What Changed
Show success toast when a category is successfully created or updated
Show error toast when category creation or update fails

Why
Users received no feedback after creating or updating categories.
This PR adds clear success and failure notifications to improve UX and prevent user confusion.

How to Test
  Sucess toast
    Go to CategoriesForm
    Create a new category
    Expect success toast
    Update an existing category
    Expect success toast
  Error toast
    Go to CategoriesForm
    Trigger validation or api failure when creating category
    Expect success toast
    Trigger validation or api failure when updating category  
    Expect success toast