### PR TITLE
Feat/task 0002 delete reports

### DIFF
--- a/frontend/src/app/components/category-list-component/category-list-component.html
+++ b/frontend/src/app/components/category-list-component/category-list-component.html
@@ -23,4 +23,5 @@
             </tr>
         </ng-template>
     </p-table>
+    <p-toast />
 </div>

--- a/frontend/src/app/components/category-list-component/category-list-component.ts
+++ b/frontend/src/app/components/category-list-component/category-list-component.ts
@@ -46,6 +46,16 @@ export class CategoryListComponent implements OnInit {
       next: res => {
         this.categories = res;
         this.showSuccessToast("Category was deleted")
+      },
+      error: (err) => {
+        let msg = 'Something went wrong';
+
+        if (err.status === 0) {
+          msg = 'Cannot connect to the server. Please try again later.';
+        } else if (err.error?.message) {
+          msg = err.error.message;
+        }
+        this.showErrorToast(msg);
       }
     }
     );

--- a/frontend/src/app/components/category-list-component/category-list-component.ts
+++ b/frontend/src/app/components/category-list-component/category-list-component.ts
@@ -34,9 +34,11 @@ export class CategoryListComponent implements OnInit {
 
   deleteCategory(id: number) {
     this.categoryService.deleteCategory(id).subscribe(() => {
-      this.categoryService.getCategories().subscribe((response) => {
-        this.categories = response;
-        this.showSuccessToast("Category was deleted")
+      this.categoryService.getCategories().subscribe({
+        next: (response) => {
+          this.categories = response;
+          this.showSuccessToast("Category was deleted")
+        }
       })
     })
   }

--- a/frontend/src/app/components/category-list-component/category-list-component.ts
+++ b/frontend/src/app/components/category-list-component/category-list-component.ts
@@ -5,17 +5,20 @@ import { OnInit } from '@angular/core';
 import { CategoryService } from '../../services/category-service';
 import { ButtonModule } from 'primeng/button';
 import { RouterLink } from '@angular/router';
+import { MessageService } from 'primeng/api';
+import { Toast } from 'primeng/toast';
 
 @Component({
   selector: 'app-category-list-component',
   standalone: true,
-  imports: [TableModule, ButtonModule, RouterLink],
+  imports: [TableModule, ButtonModule, RouterLink, Toast],
   templateUrl: './category-list-component.html',
-  styleUrl: './category-list-component.css'
+  styleUrl: './category-list-component.css',
+  providers: [MessageService]
 })
 export class CategoryListComponent implements OnInit {
 
-  constructor(private categoryService: CategoryService) { }
+  constructor(private categoryService: CategoryService, private messageService: MessageService) { }
 
   categories: Category[] = []
 
@@ -25,10 +28,15 @@ export class CategoryListComponent implements OnInit {
     })
   }
 
+  showSuccessToast(message: string) {
+    this.messageService.add({ severity: 'success', summary: 'Success', detail: message, life: 3000 });
+  }
+
   deleteCategory(id: number) {
     this.categoryService.deleteCategory(id).subscribe(() => {
       this.categoryService.getCategories().subscribe((response) => {
         this.categories = response;
+        this.showSuccessToast("Category was deleted")
       })
     })
   }

--- a/frontend/src/app/components/category-list-component/category-list-component.ts
+++ b/frontend/src/app/components/category-list-component/category-list-component.ts
@@ -7,6 +7,8 @@ import { ButtonModule } from 'primeng/button';
 import { RouterLink } from '@angular/router';
 import { MessageService } from 'primeng/api';
 import { Toast } from 'primeng/toast';
+import { switchMap } from 'rxjs';
+
 
 @Component({
   selector: 'app-category-list-component',
@@ -32,14 +34,20 @@ export class CategoryListComponent implements OnInit {
     this.messageService.add({ severity: 'success', summary: 'Success', detail: message, life: 3000 });
   }
 
+  showErrorToast(message: string) {
+    this.messageService.add({ severity: 'error', summary: 'Error', detail: message, life: 3000 });
+  }
+
   deleteCategory(id: number) {
-    this.categoryService.deleteCategory(id).subscribe(() => {
-      this.categoryService.getCategories().subscribe({
-        next: (response) => {
-          this.categories = response;
-          this.showSuccessToast("Category was deleted")
-        }
-      })
-    })
+
+    this.categoryService.deleteCategory(id).pipe(
+      switchMap(() => this.categoryService.getCategories())
+    ).subscribe({
+      next: res => {
+        this.categories = res;
+        this.showSuccessToast("Category was deleted")
+      }
+    }
+    );
   }
 }


### PR DESCRIPTION
What changed 
Show error toast when a category edit fails 
Show success toast after a category is deleted 

Why it changed 
Users received no feedback after deleting categories.
This PR adds clear success and failure notifications to improve UX and prevent user confusion.

How to Test
Success toast 
Go to CategoriesList 
Delete a category 
Expect a success toast 

Error toast 
Go to CategoriesList 
Simulate backend failure
Expect error toast
